### PR TITLE
Fix exception thrown when app suspended

### DIFF
--- a/lib/src/media_format/audio.dart
+++ b/lib/src/media_format/audio.dart
@@ -310,7 +310,7 @@ class Audio {
 
   @override
   String toString() {
-    var desc = 'MediaFormat: ${mediaFormat.name}';
+    var desc = 'MediaFormat: ${mediaFormat?.name ?? "NONE"}';
     if (_onDisk) {
       desc += 'storage: $_storagePath';
     }


### PR DESCRIPTION
When an app (that has its sound initialised) is suspended (or you pull down the control center, for example), sounds_common throws an exception (see below).

This is because `SoundPlayer._onSystemAppResumed` is called, which has this line:

       Log.d(red('onSystemAppResumed _playInBackground=$_playInBackground '
        'track=$_track'));

Which causes, eventually, `Audio.toString()` to be called, which has this line:
  
    var desc = 'MediaFormat: ${mediaFormat.name}';

Which causes an exception when `mediaFormat` is null (which mine is).

This PR fixes it by changing this debug line to:

    var desc = 'MediaFormat: ${mediaFormat?.name ?? "NONE"}';

